### PR TITLE
Reorganize into multiple packages

### DIFF
--- a/broker/clients.go
+++ b/broker/clients.go
@@ -1,0 +1,20 @@
+package hrotti
+
+import (
+	"sync"
+)
+
+// A map of clientid to Client pointer and a RW Mutex to protect access.
+type Clients struct {
+	sync.RWMutex
+	list map[string]*Client
+}
+
+// Return empty Clients (value type)
+func NewClients() Clients {
+	c := Clients{
+		sync.RWMutex{},
+		make(map[string]*Client),
+	}
+	return c
+}

--- a/broker/config.go
+++ b/broker/config.go
@@ -1,4 +1,4 @@
-package main
+package hrotti
 
 import (
 	"encoding/json"
@@ -86,7 +86,7 @@ func ParseConfig(confFile string, confVar *ConfigObject) error {
 }
 
 //set up the endpoints for the various loggers, needs to be made configurable.
-func configureLogger(infoHandle io.Writer, protocolHandle io.Writer, errorHandle io.Writer, debugHandle io.Writer) {
+func ConfigureLogger(infoHandle io.Writer, protocolHandle io.Writer, errorHandle io.Writer, debugHandle io.Writer) {
 	INFO = log.New(infoHandle,
 		"INFO: ",
 		log.Ldate|log.Ltime)

--- a/broker/internal_ids.go
+++ b/broker/internal_ids.go
@@ -1,4 +1,4 @@
-package main
+package hrotti
 
 import (
 	"sync"

--- a/broker/memory_persistence.go
+++ b/broker/memory_persistence.go
@@ -1,4 +1,4 @@
-package main
+package hrotti
 
 import (
 	"sync"

--- a/broker/messageids.go
+++ b/broker/messageids.go
@@ -1,4 +1,4 @@
-package main
+package hrotti
 
 import (
 	"sync"

--- a/broker/packets.go
+++ b/broker/packets.go
@@ -1,4 +1,4 @@
-package main
+package hrotti
 
 import (
 	"bufio"

--- a/broker/persistence.go
+++ b/broker/persistence.go
@@ -1,4 +1,4 @@
-package main
+package hrotti
 
 type PersistenceBatchEntry struct {
 	id      msgId

--- a/broker/plugin.go
+++ b/broker/plugin.go
@@ -1,4 +1,4 @@
-package main
+package hrotti
 
 import (
 	"encoding/json"

--- a/broker/queue.go
+++ b/broker/queue.go
@@ -1,4 +1,4 @@
-package main
+package hrotti
 
 import (
 	"sync"

--- a/broker/router.go
+++ b/broker/router.go
@@ -1,4 +1,4 @@
-package main
+package hrotti
 
 import (
 	"fmt"
@@ -245,7 +245,7 @@ func (n *Node) FindRecipients(topic []string, recipients chan *Entry, wg *sync.W
 	}
 }
 
-func (n *Node) DeliverMessage(topic []string, message *publishPacket) {
+func (n *Node) DeliverMessage(topic []string, message *publishPacket, hrotti *Hrotti) {
 	//to workout who we have to deliver a message to we need to trawl the topic space finding
 	//all matching subscribers on the way, due to wild card this wont necessarily be a single
 	//path from the root node to the end of the topic, and as each Node is looked at by an
@@ -314,14 +314,14 @@ func (n *Node) DeliverMessage(topic []string, message *publishPacket) {
 					case deliveryMessage.messageId = <-client.idChan:
 					case deliveryMessage.messageId = <-internalMsgIds.idChan:
 					}
-					outboundPersist.Add(client, deliveryMessage)
+					hrotti.outboundPersist.Add(client, deliveryMessage)
 					select {
 					case client.outboundMessages <- deliveryMessage:
 					default:
 					}
 				} else {
 					deliveryMessage.messageId = <-internalMsgIds.idChan
-					outboundPersist.Add(client, deliveryMessage)
+					hrotti.outboundPersist.Add(client, deliveryMessage)
 				}
 			}(client, subQos)
 		} else if client.Connected() {

--- a/broker/state.go
+++ b/broker/state.go
@@ -1,4 +1,4 @@
-package main
+package hrotti
 
 import (
 	"sync"

--- a/broker/subscriptions.go
+++ b/broker/subscriptions.go
@@ -1,4 +1,4 @@
-package main
+package hrotti
 
 import (
 	"strings"

--- a/broker/unit_client_test.go
+++ b/broker/unit_client_test.go
@@ -1,4 +1,4 @@
-package main
+package hrotti
 
 import (
 	"testing"

--- a/broker/unit_router_test.go
+++ b/broker/unit_router_test.go
@@ -1,4 +1,4 @@
-package main
+package hrotti
 
 import (
 	"fmt"

--- a/main.go
+++ b/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+
+	. "github.com/alsm/hrotti/broker"
+)
+
+func createConfig() ConfigObject {
+	configFile := flag.String("conf", "", "A configuration file")
+
+	flag.Parse()
+
+	var config ConfigObject
+
+	if *configFile == "" {
+		host := os.Getenv("HROTTI_HOST")
+		port := os.Getenv("HROTTI_PORT")
+		ws, _ := strconv.ParseBool(os.Getenv("HROTTI_USE_WEBSOCKETS"))
+		if port == "" {
+			port = "1883"
+		}
+		config.Listeners = append(config.Listeners, &ListenerConfig{host, port, ws})
+	} else {
+		err := ParseConfig(*configFile, &config)
+		if err != nil {
+			os.Stderr.WriteString(fmt.Sprintf("%s\n", err.Error()))
+		}
+	}
+	ConfigureLogger(config.GetLogTarget("info"),
+		config.GetLogTarget("protocol"),
+		config.GetLogTarget("error"),
+		config.GetLogTarget("debug"))
+	return config
+}
+
+func main() {
+	config := createConfig()
+
+	h := NewHrotti(config)
+
+	h.Run()
+}

--- a/plugins/redirect_plugin.go
+++ b/plugins/redirect_plugin.go
@@ -1,4 +1,4 @@
-package main
+package plugins
 
 import (
 	"strings"

--- a/plugins/twitter_plugin.go
+++ b/plugins/twitter_plugin.go
@@ -1,9 +1,10 @@
-package main
+package plugins
 
 import (
 	"errors"
-	"github.com/darkhelmet/twitterstream"
 	"sync"
+
+	"github.com/darkhelmet/twitterstream"
 )
 
 type Secrets struct {


### PR DESCRIPTION
Enable hrotti to be used like a library by removing global variables and moving
basically all of the code into a non-main package. The motivation for this is to
be able to use the broker in unit tests for other projects.

Right now, this breaks plugins. Since there is no dynamic linking in Go, we are stuck with either dumping plugin source code into hrotti source tree, or providing a mechanism to run plugins in their own process via RPC. My vote goes for the later, but then again I have no experience with that :8ball: 
