### PR TITLE
Reset the keep-alive timer each time a message is received.

### DIFF
--- a/broker/client.go
+++ b/broker/client.go
@@ -255,6 +255,10 @@ func (c *Client) Receive(hrotti *Hrotti) {
 				go c.Stop(true, hrotti)
 				return
 			}
+
+			// reset the keep alive timer.
+			c.ResetTimer()
+
 			switch cp.(type) {
 			//a second CONNECT packet is a protocol violation, so Stop (send will) and return.
 			case *ConnectPacket:


### PR DESCRIPTION
Currently working on a custom broker using this as a base and discovered keep-alive wasn't being reset.

Not sure if your still working on this project.

Cheers